### PR TITLE
Updating stargazers count with response data from the `addStar` mutation

### DIFF
--- a/Chapter10/Using-Apollo-Client/src/api/types.ts
+++ b/Chapter10/Using-Apollo-Client/src/api/types.ts
@@ -17,3 +17,12 @@ export type RepoData = {
     };
   };
 };
+export type StarRepoData = {
+  addStar: {
+    starrable: {
+      stargazers: {
+        totalCount: number;
+      };
+    };
+  };
+};

--- a/Chapter10/Using-Apollo-Client/src/repoPage/RepoPage.tsx
+++ b/Chapter10/Using-Apollo-Client/src/repoPage/RepoPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useLazyQuery, useMutation, useApolloClient } from '@apollo/client';
 import { GET_REPO } from '../api/getRepo';
 import { STAR_REPO } from '../api/starRepo';
-import { SearchCriteria } from '../api/types';
+import { SearchCriteria, StarRepoData } from '../api/types';
 import { SearchRepoForm } from './SearchRepoForm';
 import { FoundRepo } from './FoundRepo';
 import { StarRepoButton } from './StarRepoButton';
@@ -12,13 +12,16 @@ export function RepoPage() {
   const [getRepo, { data }] = useLazyQuery(GET_REPO);
   const queryClient = useApolloClient();
   const [starRepo] = useMutation(STAR_REPO, {
-    onCompleted: () => {
+    onCompleted: (responseData: StarRepoData) => {
       queryClient.cache.writeQuery({
         query: GET_REPO,
         data: {
           repository: {
             ...data.repository,
             viewerHasStarred: true,
+            stargazers: {
+              totalCount: responseData.addStar.starrable.stargazers.totalCount,
+            },
           },
         },
         variables: searchCriteria,


### PR DESCRIPTION
The `addStar` mutation we send looks like this

```graphql
mutation ($repoId: ID!) {
    addStar(input: { starrableId: $repoId }) {
      starrable {
        stargazers {
          totalCount
        }
      }
    }
  }
```

It's kind of useless to ask for the total count of stargazers in the response if we do nothing with this data.
Might it be something you were planning to use but forgot at the end?

This Pull Request is meant to update the stargazers total count in the Apollo client's cache after sending the mutation so the number of stars in the `FoundRepo` component gets updated immediately.